### PR TITLE
Add name property to labels

### DIFF
--- a/latest/schema.json
+++ b/latest/schema.json
@@ -33,6 +33,10 @@
             "description": "A label is used to sort and describe pull requests.",
             "type": "object",
             "properties": {
+                "name": {
+                    "description": "The name of the label.",
+                    "type": "string"
+                },
                 "description": {
                     "description": "A short description of the label. Must be 100 characters or fewer.",
                     "type": "string"


### PR DESCRIPTION
This pull request introduces a property name to labels.

[reviewpad-sig]: <>
[View on **Reviewpad**](https://beta.reviewpad.com/review/github.com/reviewpad/schemas/pull/1)
