### PR TITLE
fix: yaml multiline, issue #89

### DIFF
--- a/latest/schema.json
+++ b/latest/schema.json
@@ -19,7 +19,7 @@
         "action": {
             "description": "Action to run. This action needs to be an aladino built-in function.",
             "type": "string",
-            "pattern": "^\\$[a-zA-Z]*\\(.*\\)$",
+            "pattern": ">?\\s*\\$[a-zA-Z]*\\((.|\\s)*\\)",
             "examples": [
                 "$assignReviewer([\"john\"])",
                 "$assignReviewer($team(\"devops\"), 3)",


### PR DESCRIPTION
## Description

Fix adds support multiline strings in yaml config

## Related issue

Schema fix for Close [issue #89](https://github.com/reviewpad/reviewpad/issues/89)

## Type of change

<!-- Uncomment the right types of change from the options bellow: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

Ran `task test` command.
Use rewiewpad as CLI with this config part
```yaml
workflows:
  - name: label-pull-request-with-size
    description: Label pull request with size
    if:
      - rule: isSmall
         extra-actions:
         - >
            $addLabel("small
             multiline")
      - rule: isMedium
         extra-actions:
           - >
             $addLabel("medium
              multiline")
       - rule: isLarge
          extra-actions:
          - >
             $addLabel("large
              multiline")
```