### PR TITLE
feat: update schema

### DIFF
--- a/latest/schema.json
+++ b/latest/schema.json
@@ -33,7 +33,7 @@
         "action": {
             "description": "Action to run. This action needs to be an aladino built-in function.",
             "type": "string",
-            "pattern": ">?\\s*\\$[a-zA-Z]*\\((.|\\s)*\\)",
+            "pattern": "^!?\\$[a-zA-Z][a-zA-Z0-9-]*\\(([0-9]*|(\".*\"))?\\)",
             "examples": [
                 "$addLabel(\"large\")",
                 "$addToProject(\"reviewpad\", \"in progress\")",
@@ -153,7 +153,7 @@
                 "rule": {
                     "description": "Rule to be met. This rule can be one of the rules defined in 'rules' or it can be an inline rule.",
                     "type": "string",
-                    "pattern": "^[_a-zA-Z][a-zA-Z0-9_-]*$"
+                    "pattern": "(^!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(([0-9]*|(\".*\"))?\\))(\\s(&&|\\|\\|)\\s\\!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(([0-9]*|(\".*\"))?\\)$)?"
                 },
                 "extra-actions": {
                     "description": "List of extra actions that will be executed if the rule is met.",
@@ -168,6 +168,14 @@
                 "rule"
             ],
             "additionalProperties": false
+        },
+        "entityType": {
+            "description": "GitHub entity type that should trigger the workflow",
+            "type": "string",
+            "enum": [
+                "pull_request",
+                "issue"
+            ]
         },
         "workflow": {
             "description": "A workflow specifies a set of rules that need to be met in order to run a defined set of actions.",
@@ -187,11 +195,10 @@
                 },
                 "on": {
                     "description": "List of GitHub entity types that should trigger the workflow. By default, the value is pull_request.",
-                    "type": "string",
-                    "enum": [
-                        "pull_request",
-                        "issue"
-                    ]
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/entityType"
+                    }
                 },
                 "if": {
                     "description": "In the if field, we can specify references to multiple rules. For each rule, we can also specify a list of extra actions that will be executed if this rule is triggered.",

--- a/latest/schema.json
+++ b/latest/schema.json
@@ -33,7 +33,7 @@
         "action": {
             "description": "Action to run. This action needs to be an aladino built-in function.",
             "type": "string",
-            "pattern": "^!?\\$[a-zA-Z][a-zA-Z0-9-]*\\(([0-9]*|(\".*\"))?\\)",
+            "pattern": "^\\$[a-zA-Z][a-zA-Z0-9-]*\\(.*\\)",
             "examples": [
                 "$addLabel(\"large\")",
                 "$addToProject(\"reviewpad\", \"in progress\")",
@@ -129,8 +129,7 @@
                         "$isBinary(\"folder/filename\")",
                         "$isDraft()",
                         "$isElementOf($author(), $team(\"devops\"))",
-                        "$join([\"alice\", \"bob\"], ",
-                        ") ",
+                        "$join([\"alice\", \"bob\"], \" \") ",
                         "$labels() == [\"feat\"]",
                         "$reviewers() != []",
                         "$selectFromJSON($toJSON(\"[1, 2, 3]\"), \"$[0]\")",
@@ -153,7 +152,7 @@
                 "rule": {
                     "description": "Rule to be met. This rule can be one of the rules defined in 'rules' or it can be an inline rule.",
                     "type": "string",
-                    "pattern": "(^!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(([0-9]*|(\".*\"))?\\))(\\s(&&|\\|\\|)\\s\\!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(([0-9]*|(\".*\"))?\\)$)?"
+                    "pattern": "([a-zA-Z][a-zA-Z0-9-_]*)|(^!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(.*\\))(\\s(&&|\\|\\|)\\s\\!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(.*\\)$)?"
                 },
                 "extra-actions": {
                     "description": "List of extra actions that will be executed if the rule is met.",

--- a/latest/schema.json
+++ b/latest/schema.json
@@ -76,7 +76,7 @@
                     "description": "The hexadecimal color code for the label, with or without the leading #.",
                     "type": "string",
                     "examples": [
-                        "\"#8a2151\"",
+                        "#8a2151",
                         "d2697a"
                     ]
                 }
@@ -190,6 +190,7 @@
                     "type": "string"
                 },
                 "always-run": {
+                    "description": "Specifies if the workflow should run regardless of whether the previous workflows ran or not. By default, this field is false.",
                     "type": "boolean"
                 },
                 "on": {

--- a/latest/schema.json
+++ b/latest/schema.json
@@ -107,7 +107,6 @@
                 "spec": {
                     "description": "The spec is a boolean expression in a domain specific language called Aladino (Portuguese translation of Aladdin).",
                     "type": "string",
-                    "pattern": "^!?\\$[a-zA-Z_][a-zA-Z0-9_-]*\\((.|\\s)*(,(.|\\s)*)*\\)$",
                     "examples": [
                         "$any($reviewers(), ($r: String => $reviewerStatus($r) == \"APPROVED\"))",
                         "$approvalsCount() > 2",

--- a/latest/schema.json
+++ b/latest/schema.json
@@ -16,7 +16,7 @@
                 }
             }
         },
-        "extend": {
+        "extendedFile": {
             "type": "object",
             "properties": {
                 "url": {
@@ -81,7 +81,6 @@
                     ]
                 }
             },
-            "required": [],
             "additionalProperties": false
         },
         "rule": {
@@ -143,7 +142,6 @@
             },
             "required": [
                 "name",
-                "kind",
                 "spec"
             ],
             "additionalProperties": false
@@ -184,6 +182,17 @@
                     "description": "The description can be used to provide more details about the workflow.",
                     "type": "string"
                 },
+                "always-run": {
+                    "type": "boolean"
+                },
+                "on": {
+                    "description": "List of GitHub entity types that should trigger the workflow. By default, the value is pull_request.",
+                    "type": "string",
+                    "enum": [
+                        "pull_request",
+                        "issue"
+                    ]
+                },
                 "if": {
                     "description": "In the if field, we can specify references to multiple rules. For each rule, we can also specify a list of extra actions that will be executed if this rule is triggered.",
                     "type": "array",
@@ -199,11 +208,12 @@
                         "$ref": "#/definitions/action"
                     },
                     "minItems": 1
-                },
-                "always-run": {
-                    "type": "boolean"
                 }
             },
+            "required": [
+                "name",
+                "if"
+            ],
             "additionalProperties": false
         },
         "pipeline": {
@@ -214,6 +224,10 @@
                     "description": "The pipeline name.",
                     "type": "string",
                     "pattern": "^[_a-zA-Z][a-zA-Z0-9_-]*$"
+                },
+                "description": {
+                    "description": "The description can be used to provide more details about the pipeline.",
+                    "type": "string"
                 },
                 "trigger": {
                     "description": "A pipeline is running if and only if the trigger is empty or the rule that is specified in it is true.",
@@ -339,7 +353,7 @@
             "description": "The version of Reviewpad to be used. You can set the value to 'reviewpad.com/v3.x'.",
             "type": "string",
             "examples": [
-                "reviewpad.com/v1.x"
+                "reviewpad.com/v3.x"
             ]
         },
         "mode": {
@@ -370,7 +384,7 @@
             "description": "List of other Reviewpad configuration files as GitHub blob URLs. This allows the ability to share common specifications for all the flags, labels, rules, and workflows from multiple GitHub repositories with the possibility to override the inherited configurations.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/extend"
+                "$ref": "#/definitions/extendedFile"
             },
             "minItems": 1
         },
@@ -391,7 +405,7 @@
             "items": {
                 "$ref": "#/definitions/rule"
             },
-            "minProperties": 1,
+            "minItems": 1,
             "additionalProperties": false
         },
         "workflows": {
@@ -415,7 +429,7 @@
                     }
                 ]
             },
-            "minProperties": 1,
+            "minItems": 1,
             "additionalProperties": false
         },
         "additionalProperties": false

--- a/latest/schema.json
+++ b/latest/schema.json
@@ -107,6 +107,7 @@
                 "spec": {
                     "description": "The spec is a boolean expression in a domain specific language called Aladino (Portuguese translation of Aladdin).",
                     "type": "string",
+                    "pattern": "(^!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(.*\\))(\\s(&&|\\|\\|)\\s\\!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(.*\\)$)?",
                     "examples": [
                         "$any($reviewers(), ($r: String => $reviewerStatus($r) == \"APPROVED\"))",
                         "$approvalsCount() > 2",

--- a/latest/schema.json
+++ b/latest/schema.json
@@ -33,7 +33,7 @@
         "action": {
             "description": "Action to run. This action needs to be an aladino built-in function.",
             "type": "string",
-            "pattern": "^\\$[a-zA-Z][a-zA-Z0-9-]*\\(.*\\)$",
+            "pattern": "^\\$[a-zA-Z_][a-zA-Z0-9_-]*\\((.|\\s)*(,(.|\\s)*)*\\)$",
             "examples": [
                 "$addLabel(\"large\")",
                 "$addToProject(\"reviewpad\", \"in progress\")",
@@ -107,7 +107,7 @@
                 "spec": {
                     "description": "The spec is a boolean expression in a domain specific language called Aladino (Portuguese translation of Aladdin).",
                     "type": "string",
-                    "pattern": "(^!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(.*\\))(\\s(&&|\\|\\|)\\s\\!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(.*\\)$)?",
+                    "pattern": "^!?\\$[a-zA-Z_][a-zA-Z0-9_-]*\\((.|\\s)*(,(.|\\s)*)*\\)$",
                     "examples": [
                         "$any($reviewers(), ($r: String => $reviewerStatus($r) == \"APPROVED\"))",
                         "$approvalsCount() > 2",
@@ -153,7 +153,7 @@
                 "rule": {
                     "description": "Rule to be met. This rule can be one of the rules defined in 'rules' or it can be an inline rule.",
                     "type": "string",
-                    "pattern": "([a-zA-Z][a-zA-Z0-9-_]*)|(^!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(.*\\))(\\s(&&|\\|\\|)\\s\\!?\\$[a-zA-Z][a-zA-Z0-9-_]*\\(.*\\)$)?"
+                    "pattern": "([a-zA-Z][a-zA-Z0-9-_]*)|(^!?\\$[a-zA-Z_][a-zA-Z0-9_-]*\\((.|\\s)*(,(.|\\s)*)*\\)$)?"
                 },
                 "extra-actions": {
                     "description": "List of extra actions that will be executed if the rule is met.",

--- a/latest/schema.json
+++ b/latest/schema.json
@@ -33,7 +33,7 @@
         "action": {
             "description": "Action to run. This action needs to be an aladino built-in function.",
             "type": "string",
-            "pattern": "^\\$[a-zA-Z][a-zA-Z0-9-]*\\(.*\\)",
+            "pattern": "^\\$[a-zA-Z][a-zA-Z0-9-]*\\(.*\\)$",
             "examples": [
                 "$addLabel(\"large\")",
                 "$addToProject(\"reviewpad\", \"in progress\")",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes. -->
<!-- Also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change (if applicable.) -->
This pull request updates the schema according to the new changes of reviewpad, some of which:
- inline rules;
- `extends` feature;
- `edition` property deprecation;
- actions patterns;
- rule's `kind` property is optional;
- workflow's `on` property;
- updated actions and functions examples.

## Related issue

<!-- Closes # (issue) -->
Closes #7 

## Type of change

<!-- Uncomment the suitable types of change from the options below: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Improvements (non-breaking change without functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce (if applicable.) -->
<!-- Please also list any relevant details for your test configuration (if applicable.) -->
Manual tests were:
1. Missing `API-version` property
2. `mode` property with an invalid value (which are any values that are not `verbose` or `silent`)
3. Usage of not allowed properties (such as `label` - the correct property would be `labels`)
4. `groups` property with no values
5. `rules` property with no values
6. Missing properties in `groups`, `rules`, and `workflows`
7. Inline rules, such as:
- `$isElementOf($author(), $group("official-contributors"))` ✅ 
- `$rule("touches-license") && !$isElementOf($author(), $group("owners"))` ✅ 
- `$hasAnnotation("critical")` ✅ 
- `$hasAnnotation("critical"` ❌ 
- `contains($title(), "[ship]: ") && $isElementOf($author(), $group("owners")) ` ❌

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [x] I have run `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment and check only *one* of the following -->

<!-- - [ ] Ship: this pull request can be automatically merged and does not require code review --> 
<!-- - [ ] Show: this pull request can be auto-merged and code review should be done post-merge --> 
- [x] Ask: this pull request requires a code review before the merge
