### PR TITLE
chore: remove api version from schema

### DIFF
--- a/latest/schema.json
+++ b/latest/schema.json
@@ -362,13 +362,6 @@
         }
     },
     "properties": {
-        "api-version": {
-            "description": "The version of Reviewpad to be used. You can set the value to 'reviewpad.com/v3.x'.",
-            "type": "string",
-            "examples": [
-                "reviewpad.com/v3.x"
-            ]
-        },
         "mode": {
             "description": "The mode in which Reviewpad will run. 'verbose' to add a comment on the pull request with the triggered workflows. 'silent' to run without any comment. By default, the mode is 'silent'.",
             "type": "string",
@@ -455,8 +448,5 @@
         },
         "additionalProperties": false
     },
-    "required": [
-        "api-version"
-    ],
     "additionalProperties": false
 }

--- a/latest/schema.json
+++ b/latest/schema.json
@@ -362,6 +362,14 @@
         }
     },
     "properties": {
+        "api-version": {
+            "description": "The version of Reviewpad to be used. You can set the value to 'reviewpad.com/v3.x'.",
+            "type": "string",
+            "examples": [
+                "reviewpad.com/v3.x"
+            ],
+            "deprecated": true
+        },
         "mode": {
             "description": "The mode in which Reviewpad will run. 'verbose' to add a comment on the pull request with the triggered workflows. 'silent' to run without any comment. By default, the mode is 'silent'.",
             "type": "string",


### PR DESCRIPTION
## Description
Removes the `api-version` property from the schema.
<!-- Please include a clear and concise description of the changes. -->

## Related issue

Closes #10 
## Type of change

<!-- Please uncomment the right types of change from the options below: -->

<!-- **Bug fix** (non-breaking change which fixes an issue) -->
<!-- **New feature** (non-breaking change which adds functionality) -->
**Improvements** (non-breaking change without functionality)
<!-- **Breaking change** (fix or feature that would cause existing functionality to not work as expected) -->

## How was this tested?
Manually by using a json schema validator
<!-- Please describe the tests that you ran to verify your changes. -->

## Checklist

<!-- All checks are required in order to open a pull request ready to review. -->

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable) and have tested properly
- [ ] I have ran `task check -f` and have no issues

## Code review and merge strategy (ship/show/ask) 

<!-- Please uncomment the appropriate code review and merge strategy. -->

<!-- **Ship**: this pull request can be automatically merged and does not require code review -->
<!-- **Show**: this pull request can be auto-merged and a code review should be done post-merge -->
**Ask**: this pull request requires a code review before merge
